### PR TITLE
Include gem and yarn install in database guide

### DIFF
--- a/docs/getting-started/database.md
+++ b/docs/getting-started/database.md
@@ -12,7 +12,7 @@ application, we have built-in tools to help us.
 
 Make sure you've already installed all the dependencies
 ```
-gem install
+bundle install
 yarn install
 ```
 

--- a/docs/getting-started/database.md
+++ b/docs/getting-started/database.md
@@ -4,8 +4,17 @@ sidebar_position: 3
 
 # Preparing the Database
 
+Note: If you've already run `bin/setup`, this will have already been done for
+you.
+
 The next step is to create and prepare the database. Because Forem is a Rails
 application, we have built-in tools to help us.
+
+Make sure you've already installed all the dependencies
+```
+gem install
+yarn install
+```
 
 We can use Rails to create our database, load the schema, and add some seed
 data:
@@ -13,9 +22,6 @@ data:
 ```shell
 rails db:setup
 ```
-
-Note: If you've already run `bin/setup`, this will have already been done for
-you.
 
 `db:setup` actually runs the following rake commands in order so alternatively,
 you could run each of these to produce the same result:


### PR DESCRIPTION
Resolves https://github.com/forem/forem-docs/issues/9

This is more of a quick fix but this section could use some re-arrangement. I think what we have right now is two installation sections ("installation" and "getting started") and they are a bit in conflict with each other. I'll follow up with an issue.