### PR TITLE
fix: broken url within forem contributing guide page

### DIFF
--- a/docs/contributing-guide/forem.md
+++ b/docs/contributing-guide/forem.md
@@ -86,7 +86,7 @@ You can learn more about our internal RFC process and how we use forem.dev
 
 1. [Fork the project](https://docs.forem.com/getting-started/forking/) and clone
    it to your local machine. Follow the
-   [installation guide](https://docs.forem.com/installation/)!
+   [installation guide](https://developers.forem.com/getting-started/installation/mac)!
 2. Create a branch with your GitHub username and the ID of the
    [issue](https://github.com/forem/forem/issues), for example:
    `git checkout -b USERNAME/some-new-feature-1234`


### PR DESCRIPTION
While contributing to forem, I noticed there was a broken URL within forem documentation, this PR is to fix that.

**Before fix:**
If you go to https://developers.forem.com/contributing-guide/forem#how-to-contribute and click on the installation guide link it would take to a 404 page

<img width="1440" alt="Screenshot 2021-10-10 at 2 12 51 PM" src="https://user-images.githubusercontent.com/9020200/136688995-06f6b3d2-bb36-4bf9-99bd-6bb3c962bf1c.png">

**After fix:**

Now if you go to https://developers.forem.com/contributing-guide/forem#how-to-contribute and click on the installation guide link it will take you to the installation guide for mac

<img width="1440" alt="Screenshot 2021-10-10 at 2 12 32 PM" src="https://user-images.githubusercontent.com/9020200/136689031-a50e757f-08f0-4429-bd12-056e7a12694b.png">

