### PR TITLE
Add note that authenticated endpoints are not CORS enabled

### DIFF
--- a/api_v0.yml
+++ b/api_v0.yml
@@ -118,6 +118,8 @@ components:
         Authentication for some endpoints, like write operations on the
         Articles API require a DEV API key.
 
+        All authenticated endpoints are CORS disabled, the API key is intended for non-browser scripts.
+
         ### Getting an API key
 
         To obtain one, please follow these steps:


### PR DESCRIPTION
This amplifies the comment earlier in the api description that
non-authenticated api endpoints are CORS enabled, and seeks to avoid
frustration trying to use the api key in a browser application.

https://forem.dev/bobfornal/accessing-dev-to-apis-n5a was the initial context

https://deploy-preview-28--forem-docs.netlify.app/api#section/Authentication/api_key preview of the change here