### PR TITLE
adding a note for self-hosters

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -14,3 +14,9 @@ documents.
 This documentation site is the product of a number of volunteer contributors
 working alongside the Forem Core Team, special thanks to all those who have
 contributed to the documentation.
+
+:::important
+
+This guide does not offer development guidance for self-hosting a Forem or managing a Forem community of your own. For those who have yet to install the app that are hoping to self-host, please check out our [Forem Selfhost Installation Documentation](https://github.com/forem/selfhost-devel). If you would like to learn more about Forem Administration, please read our [Forem Admin Docs](https://admin.forem.com/).
+
+:::

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -17,6 +17,6 @@ contributed to the documentation.
 
 :::important
 
-This guide does not offer development guidance for self-hosting a Forem or managing a Forem community of your own. For those who have yet to install the app that are hoping to self-host, please check out our [Forem Selfhost Installation Documentation](https://github.com/forem/selfhost-devel). If you would like to learn more about Forem Administration, please read our [Forem Admin Docs](https://admin.forem.com/).
+To set up and self-host your own Forem we suggest using our [Forem Self-host Installation Documentation](https://github.com/forem/selfhost)
 
 :::


### PR DESCRIPTION
The community team has experienced an influx of folks who've gotten confused about which repo/guide to follow to self-host. This is an extra step to ensure self-hosters get where they need to be