### PR TITLE
Update nvm installation command

### DIFF
--- a/docs/getting-started/installation/linux.md
+++ b/docs/getting-started/installation/linux.md
@@ -32,8 +32,8 @@ There are two ways to install Yarn.
 - [DigitalOcean's detailed tutorial](https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-ubuntu-18-04)
   describes how to install
   [Node version Manager](https://github.com/creationix/nvm). By installing NVM
-  you can select a Node version (we recommend either LTS or current); the guide
-  will also explain how to install NPM. This way you'll have Node, NPM, and then
+  you can select a Node version, use `14` (matches Forem's .nvmrc and package.json files);
+  the guide will also explain how to install NPM. This way you'll have Node, NPM, and then
   you can run `npm install -g yarn` to install Yarn.
 
 ### PostgreSQL

--- a/docs/getting-started/installation/mac.md
+++ b/docs/getting-started/installation/mac.md
@@ -81,7 +81,7 @@ Forem requires a specific version of Node Package Manager (NPM).  You can use No
 
 ```shell
 brew install nvm
-nvm install --lts
+nvm install $(cat .nvmrc)
 ```
 
 You can also manage your NPM with [asdf](https://nodecli.com/nodejs-asdf).


### PR DESCRIPTION
The --lts version (currently 16) may not always match the content of the
.nvmrc (currently 14). Update the installation docs (matching the
windows install docs) to avoid problems for new setups.