### PR TITLE
Change installation instructions for nodejs on linux

### DIFF
--- a/docs/getting-started/installation/linux.md
+++ b/docs/getting-started/installation/linux.md
@@ -32,7 +32,7 @@ There are two ways to install Yarn.
 - [DigitalOcean's detailed tutorial](https://www.digitalocean.com/community/tutorials/how-to-install-node-js-on-ubuntu-18-04)
   describes how to install
   [Node version Manager](https://github.com/creationix/nvm). By installing NVM
-  you can select a Node version, use `14` (matches Forem's .nvmrc and package.json files);
+  you can select a Node version, use `16` (matches Forem's .nvmrc and package.json files);
   the guide will also explain how to install NPM. This way you'll have Node, NPM, and then
   you can run `npm install -g yarn` to install Yarn.
 


### PR DESCRIPTION
Required after, and depends on, https://github.com/forem/forem/pull/15522

Windows and Mac installation uses `$(cat .nvmrc)` to determine correct version to install.

Because the linux instructions point to an external guide, the version number to select is included as a constant in the documentation (rather than sourced from a version file).