### PR TITLE
Add user-agent header requirement to api docs

### DIFF
--- a/api_v0.yml
+++ b/api_v0.yml
@@ -14,6 +14,8 @@ info:
 
     All endpoints that don't require authentication are CORS enabled.
 
+    All requests must send a user-agent header.
+
     Dates and date times, unless otherwise specified, must be in
     the [RFC 3339](https://tools.ietf.org/html/rfc3339) format.
 


### PR DESCRIPTION
https://github.com/forem/forem/pull/15817 disallowed empty user
agents (the intent was to do this for the site, not for the api).

This restriction only applies to fastly configured forem instances (at
present, this is probably only dev.to) - but there's no reason to
overspecify.

This sentence can be removed if anonymous api requests are permitted
in the future.