### PR TITLE
Fix dead link for webpacker

### DIFF
--- a/docs/frontend/webpacker.md
+++ b/docs/frontend/webpacker.md
@@ -47,7 +47,7 @@ https://github.com/forem/forem/blob/main/config/webpack/environment.js
 ## Additional Resources
 
 For more information in regards to `javascript_packs_with_chunks_tag`, see
-https://github.com/rails/webpacker/blob/main/lib/webpacker/helper.rb
+https://github.com/rails/webpacker/blob/master/lib/webpacker/helper.rb
 
 Aside from the Webpacker repository, see also Ross Kaffenberger's
 [visual guide to Webpacker](https://rossta.net/blog/visual-guide-to-webpacker.html).


### PR DESCRIPTION
[rails/webpacker](https://github.com/rails/webpacker) is still using master as default branch.

Partially reverts 338958c29ce815ebccdefacb07ec97ae70fc1382

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>