### PR TITLE
Clarify the way dotenv is used

### DIFF
--- a/docs/backend/configuration.md
+++ b/docs/backend/configuration.md
@@ -25,6 +25,8 @@ Settings managed via your ENV can be found in
 
 ![Screenshot of env variable admin interface](/img/docs/backend/siteconfig.png)
 
+Tests always load the sample environment (and ignore the .env file). If you need to customize tests, add the environment variables to a file named .env.test.local. This prevents your development secrets from being present during test execution.
+
 ## rails-settings-cached
 
 We use this gem for managing settings used within the app's business logic.

--- a/docs/getting-started/installation/containers.md
+++ b/docs/getting-started/installation/containers.md
@@ -74,6 +74,9 @@ with Podman. You can install it by following these
 
         - You do not need "real" keys for basic development. Some features
           require certain keys, so you may be able to add them as you go.
+		  The test environment is isolated from changes to the .env file, if
+		  you want to set variables in both test and development, use a file
+		  named .env.local, or modify .env.test.local and .env.development.local.
         - The [backend guide](../../backend/configuration) will show you how to get free API keys
           for additional services that may be required to run certain parts of
           the app.

--- a/docs/getting-started/installation/linux.md
+++ b/docs/getting-started/installation/linux.md
@@ -99,7 +99,10 @@ to setup Redis.
      ```
 
    - You do not need "real" keys for basic development. Some features require
-     certain keys, so you may be able to add them as you go.
+     certain keys, so you may be able to add them as you go. The test environment
+	 is isolated from changes to the .env file, if you want to set variables in both
+	 test and development, use a file named .env.local, or modify .env.test.local
+	 and .env.development.local.
 
 1. Run `bin/setup`
 

--- a/docs/getting-started/installation/mac.md
+++ b/docs/getting-started/installation/mac.md
@@ -96,10 +96,10 @@ You can also manage your NPM with [asdf](https://nodecli.com/nodejs-asdf).
 
 3. Install bundler with `gem install bundler`
 
-   - **Note:** If you are using a Mac with an M1 CPU that uses Ruby compiled for ARM, you may need to force the platform that Bundler uses to `ruby`. This will allow you to build the C extensions used by Forem's dependencies. 
-To force the platform to use `ruby`, you can either: 
-     - set `BUNDLE_FORCE_RUBY_PLATFORM=true` in the shell environment 
-     - run `bundle config set force_ruby_platform true` to set `ruby` in Bundler globally 
+   - **Note:** If you are using a Mac with an M1 CPU that uses Ruby compiled for ARM, you may need to force the platform that Bundler uses to `ruby`. This will allow you to build the C extensions used by Forem's dependencies.
+To force the platform to use `ruby`, you can either:
+     - set `BUNDLE_FORCE_RUBY_PLATFORM=true` in the shell environment
+     - run `bundle config set force_ruby_platform true` to set `ruby` in Bundler globally
 
 4. Set up your environment variables/secrets
 
@@ -126,7 +126,10 @@ To force the platform to use `ruby`, you can either:
      ```
 
    - You do not need "real" keys for basic development. Some features require
-     certain keys, so you may be able to add them as you go.
+     certain keys, so you may be able to add them as you go. The test environment
+	 is isolated from changes to the .env file, if you want to set variables in both
+	 test and development, use a file named .env.local, or modify .env.test.local
+	 and .env.development.local.
 
 5. Run `bin/setup`
 

--- a/docs/getting-started/installation/postgresql.md
+++ b/docs/getting-started/installation/postgresql.md
@@ -42,9 +42,6 @@ connection string.
 
 ```shell
 export DATABASE_URL=postgresql://USERNAME:PASSWORD@localhost
-
-# Optional: If your test database is in a different url, be sure to set this.
-export DATABASE_URL_TEST=postgresql://USERNAME:PASSWORD@localhost
 ```
 
 1. Replace `USERNAME` with your database username, `PASSWORD` with your database
@@ -57,6 +54,13 @@ NOTE: due to how Rails merges `database.yml` and `DATABASE_URL` it's recommended
 not to add the database name in the connection string. This will default to your
 development database name also during tests, which will effectively empty the
 development DB each time tests are run.
+
+Because the test environment is loaded separately, if you are running tests and need to provide a postgresql url, set the `DATABASE_TEST_URL` variable in a file named .env.test.local
+
+```shell
+# Optional: If your test database is in a different url, be sure to set this.
+export DATABASE_URL_TEST=postgresql://USERNAME:PASSWORD@localhost
+```
 
 ## Connection Pooling
 

--- a/docs/getting-started/installation/windows.md
+++ b/docs/getting-started/installation/windows.md
@@ -224,7 +224,10 @@ WSL.
      ```
 
    - You do not need "real" keys for basic development. Some features require
-     certain keys, so you may be able to add them as you go.
+     certain keys, so you may be able to add them as you go. The test environment
+	 is isolated from changes to the .env file, if you want to set variables in both
+	 test and development, use a file named .env.local, or modify .env.test.local
+	 and .env.development.local.
 
 1. After ensuring that the PostgreSQL server and the Redis server are running,
    run `bin/setup`.


### PR DESCRIPTION
After https://github.com/forem/forem/pull/16939 the test database configuration will need to be handled outside of the local .env file (since .env_sample contains `DATABASE_URL_TEST` and `DATABASE_NAME_TEST` variables, .env file overrides will be ignored in tests).

Update the platform install docs with a note about this, update the postgresql connection instructions, and update the dotenv/.env description.

