### PR TITLE
Use issues labeled bug instead of type:bug

### DIFF
--- a/docs/contributing-guide/forem.md
+++ b/docs/contributing-guide/forem.md
@@ -22,7 +22,7 @@ contact the team with our [abuse report form](https://dev.to/report-abuse).
 All [issues](https://github.com/forem/forem/issues) labeled
 [ready for dev](https://github.com/forem/forem/issues?q=is%3Aissue+is%3Aopen+label%3A%22ready+for+dev%22)
 and
-[bug](https://github.com/forem/forem/issues?q=is%3Aissue+is%3Aopen+label%3A%22type%3A+bug%22+label%3Abug)
+[bug](https://github.com/forem/forem/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 are up for grabs. Please note that issues with the
 [Forem team](https://github.com/forem/forem/labels/Forem%20team) label are
 internal tasks that will be completed by a Forem


### PR DESCRIPTION
`https://github.com/forem/forem/issues?q=is%3Aissue+is%3Aopen+label%3A%22type%3A+bug%22+label%3Abug` looks weird. Now there is only https://github.com/forem/forem/labels?q=bug.

cf. forem/forem#17159

## Review URL(s)
- https://deploy-preview-57--forem-docs.netlify.app/contributing-guide/forem/#where-to-contribute

## Production URL(s)
- https://developers.forem.com/contributing-guide/forem/#where-to-contribute

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>