### PR TITLE
Remove customize spacing-horizontal to use default

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -10,7 +10,6 @@
   --ifm-color-primary: #005b30;
   --ifm-code-font-size: 95%;
   --ifm-footer-background-color: #022830;
-  --ifm-spacing-horizontal: 3rem;
 }
 
 


### PR DESCRIPTION
Defaults `--ifm-spacing-horizontal: 1rem` instead of `3rem`.

Closes #58

### Screenshots after changes

Padding in the main container would be reset as default of Docusaurus/Infima (`1rem`).

| - | Mobile | Small-screen PC |
|-|-|-|
| to-be | ![mobile-1rem](https://user-images.githubusercontent.com/10229505/162619065-f45d40e9-b2ac-4fa6-a025-c51c1c38c1fb.png) | ![pc-1rem](https://user-images.githubusercontent.com/10229505/162619068-08dae584-d81c-4b97-b5c2-773a89c95959.png) |

### Resources
- https://github.com/facebookincubator/infima/blob/cc215af837064d9cce3eb5ca12836c3499b5c547/packages/core/styles/common/variables.pcss#L131

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>