### PR TITLE
Update caniuse-lite npm package to 1.0.30001331

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,15 +3088,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001196, caniuse-lite@^1.0.30001219:
-  version "1.0.30001228"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz"
-  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
-
-caniuse-lite@^1.0.30001243:
-  version "1.0.30001249"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz#90a330057f8ff75bfe97a94d047d5e14fabb2ee8"
-  integrity sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001196, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001243:
+  version "1.0.30001331"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001331.tgz"
+  integrity sha512-Y1xk6paHpUXKP/P6YjQv1xqyTbgAP05ycHBcRdQjTcyXlWol868sJJPlmk5ylOekw2BrucWes5jk+LvVd7WZ5Q==
 
 ccount@^1.0.0, ccount@^1.0.3:
   version "1.1.0"


### PR DESCRIPTION
with the following command: `npx browserslist@latest --update-db`

### Target changes
```diff
Target browser changes:
- and_chr 90
+ and_chr 100
- chrome 90
- chrome 89
- chrome 88
+ chrome 99
+ chrome 98
+ chrome 97
- edge 90
- edge 89
+ edge 99
+ edge 98
- firefox 88
- firefox 87
+ firefox 98
+ firefox 97
- ios_saf 13.4-13.7
+ ios_saf 15.4
+ ios_saf 15.2-15.3
+ ios_saf 15.0-15.1
+ ios_saf 14.5-14.8
+ ios_saf 12.2-12.5
- opera 75
- safari 14
+ safari 14.1
- samsung 14.0
- samsung 13.0
+ samsung 16.0
```

### Why
This change will suppress the following warning as well:

```
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
```

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>