### PR TITLE
Underline links in only Markdown region

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -12,20 +12,15 @@
   --ifm-footer-background-color: #022830;
 }
 
-
 html[data-theme='dark'] {
   --ifm-color-primary: #FBC1F5;
   --ifm-background-color: #022830;
   --ifm-navbar-background-color: #022830;
 }
 
-.container a,
-.container a:hover {
+.theme-doc-markdown a,
+.theme-doc-markdown a:hover {
   text-decoration: underline;
-}
-
-.pagination-nav__item a {
-  text-decoration: none;
 }
 
 .footer {


### PR DESCRIPTION
Underline links in only Markdown region, i.e., remove underlines from (breadcrumbs), collapsible TOC (for mobile screen), footer including "Edit this page". Redundant CSS `.pagination-nav__item a` for navigations under the footer can be removed as well. Additional opinionated changes are made in the `<footer>`, which is the default style in Docusaurus default.

## Area to apply `text-decoration: underline` before/after the patch
| before this patch | after this patch |
|-|-|
| ![container-1](https://user-images.githubusercontent.com/10229505/163894856-6baa3b34-d76d-42aa-811c-5190b43ce445.png) | ![theme-doc-markdown](https://user-images.githubusercontent.com/10229505/163895380-16160ef6-e805-43a4-a9d8-5c1173f257a9.png) |

## Additional opinionated changes in `<footer>`
| before this patch | after this patch |
|-|-|
| ![developers forem com_technical-overview_stack](https://user-images.githubusercontent.com/10229505/163895626-0cc76f3f-37a8-4b0c-bd79-282eb11c4084.png) | ![3000-forem-foremdocs-xvxy72t2s6p ws-us40 gitpod io_](https://user-images.githubusercontent.com/10229505/163895633-b9f0a9b1-0810-4aff-a50f-8fd223dac36c.png) |

Fixes up #1

Closes #68

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>