### PR TITLE
Fixed organization's articles cURL example

### DIFF
--- a/api_v0.yml
+++ b/api_v0.yml
@@ -3188,7 +3188,7 @@ paths:
         - lang: Shell
           label: curl
           source: |
-            curl https://dev.to/api/organizations/ecorp/listings
+            curl https://dev.to/api/organizations/ecorp/articles
 
   /podcast_episodes:
     get:


### PR DESCRIPTION
In the example the URL is `curl https://dev.to/api/organizations/ecorp/listings` but it should be `curl https://dev.to/api/organizations/ecorp/articles`.