### PR TITLE
Fix "rails not found in path" error.

### DIFF
--- a/docs/getting-started/installation/containers.md
+++ b/docs/getting-started/installation/containers.md
@@ -122,5 +122,5 @@ The script executes the following steps:
   run the following command:
 
   ```shell
-  docker-compose run rails rails data_updates:run
+  docker-compose run rails bundle exec rails data_updates:run
   ```


### PR DESCRIPTION
# Description
When running data_updates, `bundle exec` needs to be prepended to `rails`, so the container knows which version of rails to use. Without this the command returns an error about rails not being found in the path: `Error starting command: `rails` - exec: "rails": executable file not found in $PATH`
![error without bundle exec, and success with it](https://user-images.githubusercontent.com/8124558/195110055-f8caf8af-d857-4cf7-9040-3a8f5c09454f.png)
