### PR TITLE
Developer Onboarding Simplification

### DIFF
--- a/docs/getting-started/installation/mac.md
+++ b/docs/getting-started/installation/mac.md
@@ -6,102 +6,64 @@ sidebar_position: 1
 
 **Installing Forem on macOS**
 
-## Installing prerequisites
+> This spins up a Forem stack for local development with no use of containerization, virtualization, etc., which comes with tradeoffs: standing up the stack will almost invariably be a slower process as various tools build from source, but attaching debuggers and the like to the resulting Forem application will be easier, not to mention the lack of I/O overhead that comes with, for example, running a full Linux VM to run containers in (which, for example, Docker Desktop does). However, more cruft gets left behind when you're done working: you'll have PostgreSQL databases and so forth to clean up. If you'd rather take the containers side of the tradeoffs, [those docs are here](containers.md).
 
-### Ruby
+_For maintainer sanity reasons, this opinionated and curated instruction set assumes you're cool with the use of [Homebrew](https://brew.sh) to install certain system-wide dependencies, and  [rtx](https://github.com/jdx/rtx) to install specific versions of Ruby, NodeJS, Yarn (a JS package manager), PostgreSQL (a database), and Redis (an in-memory cache) that are tricky to version-lock system-wide. If these package managers are for any reason a non-starter for you, you'll want to use your package management solutions of choice to install the tools found in `.rtx.toml`, `.ruby-version`, and `.nvmrc`, at the appropriate versions, and should be comfortable sorting out the dependencies thereof on your own._
 
-1. **Note:** MacOS ships with a version of Ruby, needed for various operating
-   systems. To avoid causing an issue with your operating system you should use
-   a version manager for Ruby.
+_This has been tested on Apple Silicon Macs, but should be expected to work without noteworthy modification on Intel Macs. If you find a setup issue on Intel Macs, [file an issue with us](https://github.com/forem/forem/issues)._
 
-   If you don't already have a Ruby version manager, we highly recommend
-   [rbenv](https://github.com/rbenv/rbenv). This will allow you to have
-   different versions running on a per project basis. The MacOS system version
-   of Ruby will stay intact while giving you the ability to use the version
-   needed for this Forem project. Please follow their
-   [installation guide](https://github.com/rbenv/rbenv#installation).
+## Installing Package Managers
 
-2. With the Ruby version manager, install the Ruby version listed on our badge.
-   (i.e. with rbenv: `rbenv install $(cat .ruby-version)`)
+To start, we need to install (two of the three...) package managers that we'll use later in the guide: [Homebrew](https://brew.sh) and [rtx](https://github.com/jdx/rtx). Follow whatever their current instructions are at those links, and then come back here. Notably for rtx, make sure you've configured the appropriate shell integration (you probably should have seen something about `eval` and a `bashrc` or `zshrc`!).
 
-   **Note:** The repository must be forked and cloned before running the
-   `rbenv install $(cat .ruby-version)` command.
+## Pulling Forem's Code
 
-### Yarn
+Using Homebrew (or [alternative means, if desired](https://docs.github.com/en/get-started/quickstart/set-up-git)), we need to install `git` a version control system we use in the development of Forem (with GitHub as our canonical host for the Git repository), and then this section is reasonably straightforward.
+ 
+> Those with the Xcode Command Line Tools already installed, for example those using AWS EC2 Mac instances in the cloud, will alerady have a working Git install at `/usr/bin/git`. That's fine: let's install Homebrew's version anyway, for consistency, unless you really know what you're doing.
 
-Please refer to their [installation guide](https://yarnpkg.com/en/docs/install).
+1. `brew install git`
+2. Fork Forem's repository [using this GitHub link](https://github.com/forem/forem/fork). Forking is optional to read our code, but will be necessary to submit changes to us, so this is a helpful bit of upfront house-keeping.
+3. Clone your forked repository:
 
-### PostgreSQL
+  - With HTTPS: `git clone https://github.com/<your-username>/forem.git`
+  - With SSH: `git clone git@github.com:<your-username>/forem.git`
+  - Or, use a graphical Git client of your choosing, the selection of which is outside the scope of this document.
 
-Forem requires PostgreSQL version 11 or higher to run.
+4. Then, change directories into the clone: `cd forem`
 
-The easiest way to get started is to use
-[Postgres.app](https://postgresapp.com/). Alternatively, check out the official
-[PostgreSQL](https://www.postgresql.org/) site for more installation options.
+## Installing System-Level Dependencies
 
-For additional configuration options, check our
-[PostgreSQL setup guide](postgresql.md).
+> This is the part where, if you've opted out of Homebrew, you'll need to round up a few tools on your own. Most notably, [ImageMagick](https://imagemagick.org/script/download.php#macosx) is somewhat non-trivial.
 
-### ImageMagick
+Homebrew makes this step quick: run `brew bundle`, and assuming it finishes successfully, you're done. This step should only fail if Homebrew is not installed correctly, or there is a version conflict between what we depend on for Forem, and whatever you might already have installed on your system (`gpg` is a potential candidate here). In the event of such a collision, you can either uninstall the existing package on your system, or skip the failed package for now and attempt to complete these setup instructions anyway. It might work. If not, open an issue with us and we'll see if we can help.
 
-Forem uses [ImageMagick](https://imagemagick.org/) to manipulate images on
-upload.
+## Installing Version-Locked Tool Dependencies
 
-You can install ImageMagick by issuing the following command:
-```shell
-brew install imagemagick
-```
+> This is the part where, if you've opted out of `rtx`, you'll need to round up tools on your own. For Ruby, consider setting up `rbenv` using their [installation guide](https://github.com/rbenv/rbenv#installation) and then installing our current Ruby version target with `rbenv install $(cat .ruby-version)`. For NodeJS, consider `nvm` and install our Node version target with `nvm install`. You're on your own for installing [Yarn v1](https://yarnpkg.com/en/docs/install), [PostgreSQL v13](https://www.postgresql.org/) (perhaps via [Postgres.app](https://postgresapp.com/), also see our [auxiliary documentation](postgresql.md)), and [Redis](https://redis.io/docs/getting-started/installation/install-redis-on-mac-os/).
 
-### Redis
+Use `rtx install` - this will pull the exact versions we recommend for the tools listed in the block above, which helps to prevent "version drift" - where someone writes code targeting Version A of some tool, but it breaks when run against Version B of that same tool.
 
-Forem requires Redis version 6.0 or higher to run.
+If prompted, respond `y` to the prompts about installing plugins to handle Yarn, PostgreSQL, and Redis.
 
-We recommend using [Homebrew](https://brew.sh):
+**This step will probably take several minutes**: it's building most of these dependencies from source code. Errors at this point are unlikely, but if they pop up, should be expected to be quite varied: searching for error messages will often lead to helpful solutions, as few to none of these errors are likely to have never been seen (and triaged) before.
 
-```shell
-brew install redis
-```
+## Last Bits Of Setup
 
-you can follow the post installation instructions, we recommend using
-`brew services` to start Redis in the background:
+1. Start the caching server with `redis-server --daemonize yes` (do this every time you work on Forem!)
 
-```shell
-brew services start redis
-```
+2. Start and configure the database (which requires some tinkering to avoid future errors; copy pasting is fine here!)
 
-You can test if it's up and running by issuing the following command:
+  - `pg_ctl start` - do this every time you work on Forem!
+  - `createuser -U postgres -s $(whoami)`, which creates a PostgreSQL user by your system username. This only needs done once.
+  - Now we need to change the default encoding of the database. These steps are copied nearly verbatim from [the Arch Linux wiki](https://wiki.archlinux.org/title/PostgreSQL#Change_default_encoding_of_new_databases_to_UTF-8). Run them one-by-one.
 
-```shell
-redis-cli ping
-```
+    * `psql -d postgres -c "UPDATE pg_database SET datistemplate = FALSE WHERE datname = 'template1';"`
+    * `psql -d postgres -c "DROP  DATABASE template1;"`
+    * `psql -d postgres -c "CREATE DATABASE template1 WITH TEMPLATE = template0 ENCODING = 'UNICODE';"`
+    * `psql -d postgres -c "UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template1';"`
 
-### NPM
-
-Forem requires a specific version of Node Package Manager (NPM).  You can use Node Version Management (NVM) to help you manage your NPM setup. (see [NVM vs. NPM vs. Yarn](https://github.com/ndlib/marble-blueprints/pull/327)).
-
-```shell
-brew install nvm
-nvm install $(cat .nvmrc)
-```
-
-You can also manage your NPM with [asdf](https://nodecli.com/nodejs-asdf).
-
-## Installing Forem
-
-1. Fork Forem's repository, e.g. <https://github.com/forem/forem/fork>
-2. Clone your forked repository in one of two ways:
-
-   - e.g. with HTTPS: `git clone https://github.com/<your-username>/forem.git`
-   - e.g. with SSH: `git clone git@github.com:<your-username>/forem.git`
-
-3. Install bundler with `gem install bundler`
-
-   - **Note:** If you are using a Mac with an M1 CPU that uses Ruby compiled for ARM, you may need to force the platform that Bundler uses to `ruby`. This will allow you to build the C extensions used by Forem's dependencies.
-To force the platform to use `ruby`, you can either:
-     - set `BUNDLE_FORCE_RUBY_PLATFORM=true` in the shell environment
-     - run `bundle config set force_ruby_platform true` to set `ruby` in Bundler globally
-
-4. Set up your environment variables/secrets
+3. Set up your environment variables/secrets
 
    - Take a look at `.env_sample` to see all the `ENV` variables we use and the
      fake default provided for any missing keys.
@@ -131,15 +93,47 @@ To force the platform to use `ruby`, you can either:
 	 test and development, use a file named .env.local, or modify .env.test.local
 	 and .env.development.local.
 
-5. Run `bin/setup`
+4. Do final application setup (including the installation of requisite Ruby gems and NodeJS modules) with `./bin/setup`.
+
+## Start Up Your Forem!
+
+```sh
+./bin/startup
+```
+
+Presuming no errors here, your Forem should be accessible at `http://localhost:3000`.
+
+To run unit tests, first, prepare the database:
+
+```sh
+./bin/rails db:test:prepare RAILS_ENV=test
+```
+
+Then, try running any test, for example:
+
+```sh
+./bin/rspec spec/lib/acts_as_taggable_on
+```
+
+To shut down your Forem stack when you're done tinkering, shut services down in the inverse order of how we started them:
+
+- Press `Ctrl-C` to stop the Forem server process that's currently in the foreground
+- `pg_ctl stop` will shut down the database
+- `redis-cli SHUTDOWN` will stop the caching server
 
 ### Possible error messages
+
+This section serves as a collection of various things that have gone wrong in the past while setting up Forem on Macs: not all of them are necessarily common anymore, and in particular many of them impact `rbenv`-based setups more than `rtx`-based setups (so far), but they're preserved here just in case.
+
+---
 
 **Error:** `rbenv install hangs at ruby-build: using readline from homebrew`
 
 **_Solution:_**
 [Stackoverflow answer](https://stackoverflow.com/questions/63599818/rbenv-install-hangs-at-ruby-build-using-readline-from-homebrew)
 `RUBY_CONFIGURE_OPTS=--with-readline-dir="$(brew --prefix readline)" rbenv install 2.0.0`
+
+---
 
 **Error:**
 `__NSPlaceholderDate initialize] may have been in progress in another thread when fork() was called`


### PR DESCRIPTION
This is the documentation part of the bare-metal developer onboarding simplification work I've been tinkering with, which depends on forem/forem#20077.

I have the MacOS equivalent update in progress on my disk - I wanted to have the Linux side *rock solid* and tested a couple times smoothly before doing the (for me, at least) more complex case, and now need to fix access to my AWS account before I can do the final test pass on that :facepalm: So for now, this one's Linux-only. I'll either amend this PR to add the MacOS bits, or open a fast-follow as soon as I'm done spinning up a Mac EC2 instance to test and doing this like committing the Homebrew lock file.

On an AMD 6900HX system with a Debian 12 QEMU VM, I went from "first login to the system" to "example unit tests passing" in less than 20 minutes, using only copy-pasted instructions from this guide and no further Linux or Forem knowledge. This time includes compiling Redis, PostgreSQL, and Ruby all from source via `rtx`, and so will vary system-to-system. To say I'm thrilled with this outcome is an understatement, as our goal was ~30min.

The tradeoff here is that I've largely killed off all the "there's more than one way to do it" paths that used to exist in this documentation. I don't completely disavow doing things any other way, but the docs now explicitly tell you you're on your own if, for some reason, any of our opinions don't match your own, and give hints on where to look for tool versions to go fend for yourself.