### PR TITLE
[20518]: Update API v0 docs with correct summary

### DIFF
--- a/api_v0.yml
+++ b/api_v0.yml
@@ -3469,7 +3469,7 @@ paths:
   /admin/users:
     post:
       operationId: postAdminUsersCreate
-      summary: Invites a user to the Forem instannce
+      summary: Invites a user to the Forem Instance
       description: |
         This endpoint allows the client to trigger an invitation to the
         provided email address.


### PR DESCRIPTION
Bug Reported:
https://github.com/forem/forem/issues/20518

I have fixed the typo error in the summary of this api `/admin/users`

Current API Doc:
https://developers.forem.com/api/v0#tag/users/operation/postAdminUsersCreate
"Invites a user to the Forem instannce"


Expected API Doc Resolving Typo:
"instannce" should be "instance" where the text is "Invites a user to the Forem instannce"